### PR TITLE
Add validation for life policy form and disable continue button 

### DIFF
--- a/src/app/views/pages/customers/add-customers/add-customers.component.html
+++ b/src/app/views/pages/customers/add-customers/add-customers.component.html
@@ -948,6 +948,7 @@
                   class="btn btn-primary mx-1"
                   type="submit"
                   title="Continue"
+                  [disabled]="!isLifePolicyFormValid"
                 >
                   Continue
                 </button>

--- a/src/app/views/pages/customers/add-customers/add-customers.component.ts
+++ b/src/app/views/pages/customers/add-customers/add-customers.component.ts
@@ -258,6 +258,14 @@ export class AddCustomersComponent implements OnInit, OnDestroy {
     return this.referralsForm.get('referrals') as FormArray;
   }
 
+  get isLifePolicyFormValid(): boolean {
+    return (
+      this.lifePolicyForm.valid &&
+      !this.messagesEmail &&
+      !this.messagesDocumentNumbert
+    );
+  }
+
   formLifePolicySubmit() {
     if (this.lifePolicyForm.valid) {
       this.createClient(this.lifePolicyForm.value);


### PR DESCRIPTION
This pull request adds validation logic to the "Continue" button in the Add Customers page, ensuring that users can only proceed when the life policy form is valid and there are no email or document number error messages.

**Form validation improvements:**

* Added a new getter `isLifePolicyFormValid` in `AddCustomersComponent` to check that `lifePolicyForm` is valid and there are no email or document number error messages.
* Updated the "Continue" button in `add-customers.component.html` to be disabled unless `isLifePolicyFormValid` is true.