### PR TITLE
Add required validation for doctor's office location in medical forms

### DIFF
--- a/src/app/views/pages/customers/add-customers/add-customers.component.html
+++ b/src/app/views/pages/customers/add-customers/add-customers.component.html
@@ -1530,12 +1530,28 @@
 
                 <div class="col-sm-4">
                   <div class="mb-3">
-                    <label class="form-label">Doctor's Office Location</label>
+                    <label class="form-label required"
+                      >Doctor's Office Location</label
+                    >
                     <input
                       type="text"
                       class="form-control"
                       formControlName="doctorOfficeLocation"
+                      [ngClass]="{
+                        'is-invalid':
+                          isMedicalFormFormSubmitted &&
+                          formMedical.doctorOfficeLocation.errors
+                      }"
                     />
+                    <div
+                      *ngIf="
+                        isMedicalFormFormSubmitted &&
+                        formMedical.doctorOfficeLocation.errors?.required
+                      "
+                      class="invalid-feedback"
+                    >
+                      Required
+                    </div>
                   </div>
                 </div>
 

--- a/src/app/views/pages/customers/add-customers/add-customers.component.ts
+++ b/src/app/views/pages/customers/add-customers/add-customers.component.ts
@@ -152,7 +152,7 @@ export class AddCustomersComponent implements OnInit, OnDestroy {
 
     this.medicalForm = this.formBuilder.group({
       doctorName: ['', [Validators.required]],
-      doctorOfficeLocation: ['', []],
+      doctorOfficeLocation: ['', [Validators.required]],
       officePhoneNumber: ['', []],
       lastVisit: ['', [Validators.required]],
       reasonForVisit: ['', [Validators.required]],

--- a/src/app/views/pages/policy/add-policy/add-policy.component.html
+++ b/src/app/views/pages/policy/add-policy/add-policy.component.html
@@ -919,12 +919,28 @@
 
                 <div class="col-sm-4">
                   <div class="mb-3">
-                    <label class="form-label">Doctor's Office Location</label>
+                    <label class="form-label required"
+                      >Doctor's Office Location</label
+                    >
                     <input
                       type="text"
                       class="form-control"
                       formControlName="doctorOfficeLocation"
+                      [ngClass]="{
+                        'is-invalid':
+                          isMedicalFormFormSubmitted &&
+                          formMedical.doctorOfficeLocation.errors
+                      }"
                     />
+                    <div
+                      *ngIf="
+                        isMedicalFormFormSubmitted &&
+                        formMedical.doctorOfficeLocation.errors?.required
+                      "
+                      class="invalid-feedback"
+                    >
+                      Required
+                    </div>
                   </div>
                 </div>
 

--- a/src/app/views/pages/policy/add-policy/add-policy.component.ts
+++ b/src/app/views/pages/policy/add-policy/add-policy.component.ts
@@ -141,7 +141,10 @@ export class AddPolicyComponent implements OnInit {
         { value: '', disabled: this.isDisabled },
         [Validators.required],
       ],
-      doctorOfficeLocation: [{ value: '', disabled: this.isDisabled }, []],
+      doctorOfficeLocation: [
+        { value: '', disabled: this.isDisabled },
+        [Validators.required],
+      ],
       officePhoneNumber: [{ value: '', disabled: this.isDisabled }, []],
       lastVisit: [
         { value: '', disabled: this.isDisabled },


### PR DESCRIPTION
This pull request updates the medical forms in both the Add Customer and Add Policy workflows to make the "Doctor's Office Location" field required. It also improves the user interface by providing immediate visual feedback and error messages when this field is left empty.

**Form validation and UI improvements:**

* Made the `doctorOfficeLocation` field required in both the `AddCustomersComponent` and `AddPolicyComponent` form definitions to enforce validation at the form level. [[1]](diffhunk://#diff-63c04d7f7d862e6f88115b53eff5e0b0d3ef7d1002d59d2e49ba2451c333e2dcL155-R155) [[2]](diffhunk://#diff-ce206ec31abdc829be4b0fe69bfdeec1b0158be6c6494811a732072bc87ebd01L144-R147)
* Updated the corresponding HTML templates to:
  * Add the "required" class to the label for visual indication.
  * Apply the `is-invalid` CSS class to the input when the field is invalid after form submission.
  * Display an inline "Required" error message if the field is empty upon submission. [[1]](diffhunk://#diff-2e95d13d325c72eac4495befc5a0d9652f5a2a299ef7cb1cbc4eddbfea906403L1533-R1554) [[2]](diffhunk://#diff-194e5d557532c8229bac6c1118f35ab4578b38cf5cea8e27a8974ef638ee6405L922-R943)